### PR TITLE
Fixing a typo in values.yaml

### DIFF
--- a/helm-chart/values.yaml
+++ b/helm-chart/values.yaml
@@ -76,7 +76,7 @@ binderhub:
       pdb:
         minAvailable: 0
       https:
-        enablde: false
+        enabled: false
       service:
         type: NodePort
         nodePorts:


### PR DESCRIPTION
Hiya, I'm going through the persistent storage deployment and found a small typo in the config :)